### PR TITLE
add DRF for subscribers and plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ Will launch the api.
 You can use the .env file provided for convenience or make changes as necessary
 
 ## Note on default data 
-When the server launches it will create a default user dev and the default plans, basic, premium and enterprise
+When the server launches it will create a default user dev and admin and the default plans, basic, premium and enterprise.
+The admin password is specified in .env
+
+## DRF endpoints
+The following endpoints can be used to create their respective objects!
+http://localhost:8000/subscribers/
+http://localhost:8000/plans/
+http://localhost:8000/users/
 
 ## POSTING
 

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -32,6 +32,11 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 # Application definition
 
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
+}
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -40,6 +45,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "image.apps.ImageConfig",
+    "rest_framework",
 ]
 
 MIDDLEWARE = [

--- a/app/image/urls.py
+++ b/app/image/urls.py
@@ -1,6 +1,19 @@
-from django.urls import path
-from image.views import (fetch_thumbnails, list_images, serve_original_image,
-                         upload_image)
+from django.urls import path, include
+from rest_framework import routers
+
+from image.views import (
+    fetch_thumbnails,
+    list_images,
+    serve_original_image,
+    upload_image,
+    SubscriberCreateView,
+    PlanListCreateView,
+)
+
+
+router = routers.DefaultRouter()
+router.register(r"subscribers", SubscriberCreateView)
+router.register(r"plans", PlanListCreateView)
 
 urlpatterns = [
     path("upload/", upload_image, name="upload_image"),
@@ -13,4 +26,6 @@ urlpatterns = [
     path(
         "source_image/<str:image_id>", serve_original_image, name="serve_original_image"
     ),
+    path("", include(router.urls)),
+    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
 ]

--- a/app/image/urls.py
+++ b/app/image/urls.py
@@ -8,14 +8,14 @@ from image.views import (
     upload_image,
     SubscriberCreateView,
     PlanListCreateView,
-    UserViewSet
+    UserViewSet,
 )
 
 
 router = routers.DefaultRouter()
 router.register(r"subscribers", SubscriberCreateView)
 router.register(r"plans", PlanListCreateView)
-router.register(r'users', UserViewSet)
+router.register(r"users", UserViewSet)
 
 urlpatterns = [
     path("upload/", upload_image, name="upload_image"),

--- a/app/image/urls.py
+++ b/app/image/urls.py
@@ -8,12 +8,14 @@ from image.views import (
     upload_image,
     SubscriberCreateView,
     PlanListCreateView,
+    UserViewSet
 )
 
 
 router = routers.DefaultRouter()
 router.register(r"subscribers", SubscriberCreateView)
 router.register(r"plans", PlanListCreateView)
+router.register(r'users', UserViewSet)
 
 urlpatterns = [
     path("upload/", upload_image, name="upload_image"),

--- a/app/image/views.py
+++ b/app/image/views.py
@@ -11,7 +11,7 @@ from PIL import Image as image_processor
 
 from rest_framework import generics, permissions
 from image.models import Subscriber, Plan
-from image.serializers import SubscriberSerializer, PlanSerializer
+from image.serializers import SubscriberSerializer, PlanSerializer, UserSerializer
 from rest_framework import mixins, viewsets
 
 
@@ -121,3 +121,12 @@ class SubscriberCreateView(viewsets.ModelViewSet):
     queryset = Subscriber.objects.all()
     serializer_class = SubscriberSerializer
     permission_classes = [permissions.IsAdminUser]
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+    queryset = User.objects.all().order_by('-date_joined')
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/app/image/views.py
+++ b/app/image/views.py
@@ -127,6 +127,7 @@ class UserViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows users to be viewed or edited.
     """
-    queryset = User.objects.all().order_by('-date_joined')
+
+    queryset = User.objects.all().order_by("-date_joined")
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]

--- a/app/image/views.py
+++ b/app/image/views.py
@@ -1,4 +1,3 @@
-
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
@@ -6,10 +5,14 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
-from image.helpers import (convert_to_bytes, get_user, link_not_expired,
-                           user_exists)
+from image.helpers import convert_to_bytes, get_user, link_not_expired, user_exists
 from image.models import Image, Link
 from PIL import Image as image_processor
+
+from rest_framework import generics, permissions
+from image.models import Subscriber, Plan
+from image.serializers import SubscriberSerializer, PlanSerializer
+from rest_framework import mixins, viewsets
 
 
 @csrf_exempt
@@ -98,3 +101,23 @@ def get_expiry_date(expires_in):
     if expires_in is None:
         return None
     return timezone.timedelta(seconds=expires_in) + timezone.now()
+
+
+class PlanListCreateView(viewsets.ModelViewSet):
+    """
+    API endpoint that allows plans to be viewed or edited.
+    """
+
+    queryset = Plan.objects.all()
+    serializer_class = PlanSerializer
+    permission_classes = [permissions.IsAdminUser]
+
+
+class SubscriberCreateView(viewsets.ModelViewSet):
+    """
+    API endpoint that allows Subscribers to be viewed or edited.
+    """
+
+    queryset = Subscriber.objects.all()
+    serializer_class = SubscriberSerializer
+    permission_classes = [permissions.IsAdminUser]

--- a/app/run.sh
+++ b/app/run.sh
@@ -3,5 +3,5 @@
 python manage.py makemigrations
 python manage.py migrate
 python manage.py startup
-
+python manage.py createsuperuser --noinput 
 python manage.py runserver 0.0.0.0:8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pillow==8.4.0
 debugpy==1.5.1
 redis==4.3.0
 django-redis==5.2.0
+djangorestframework==3.14.0


### PR DESCRIPTION
Adds the following endpoints for the quick creation of users, plans and subscribers: 
- http://localhost:8000/subscribers/
- http://localhost:8000/plans/
- http://localhost:8000/users/
also adds changes to `run.sh` that creates a superuser `admin` for convenience 